### PR TITLE
Specify columns explicitly at insert time

### DIFF
--- a/lib/shared-secrets.def.php
+++ b/lib/shared-secrets.def.php
@@ -13,7 +13,7 @@
 
   # define MySQL queries
   define("MYSQL_READ",  "SELECT COUNT(*) FROM secrets WHERE fingerprint = ?");
-  define("MYSQL_WRITE", "INSERT IGNORE INTO secrets VALUES (?, ?, CURRENT_TIMESTAMP)");
+  define("MYSQL_WRITE", "INSERT IGNORE INTO secrets (keyid, fingerprint, time) VALUES (?, ?, CURRENT_TIMESTAMP)");
 
   # define page names
   define("HOW_PAGE_NAME",     "how");


### PR DESCRIPTION
* specify keyid, fingerprint, time columns explicitly in insert statement
* make code more resilient to work with future schema changes that may introduce columns with default values
* make code more robust if order of columns should ever change